### PR TITLE
Pass clicked HTML element that triggered the event

### DIFF
--- a/demoapp/src/main/java/com/basecamp/turbolinks/demo/MainActivity.java
+++ b/demoapp/src/main/java/com/basecamp/turbolinks/demo/MainActivity.java
@@ -90,7 +90,7 @@ public class MainActivity extends AppCompatActivity implements TurbolinksAdapter
     // you can just open another activity, or in more complex cases, this would be a good spot for
     // routing logic to take you to the right place within your app.
     @Override
-    public void visitProposedToLocationWithAction(String location, String action) {
+    public void visitProposedToLocationWithAction(String location, String action, String target) {
         Intent intent = new Intent(this, MainActivity.class);
         intent.putExtra(INTENT_URL, location);
 

--- a/turbolinks/src/main/assets/js/turbolinks_bridge.js
+++ b/turbolinks/src/main/assets/js/turbolinks_bridge.js
@@ -54,7 +54,12 @@ TLWebView.prototype = {
     // -----------------------------------------------------------------------
 
     visitProposedToLocationWithAction: function(location, action, target) {
-        TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action, target.outerHTML);
+        var targetHTML = ""
+        if (target !== null) {
+            targetHTML = target.outerHTML;
+        }
+
+        TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action, targetHTML);
     },
 
     visitStarted: function(visit) {

--- a/turbolinks/src/main/assets/js/turbolinks_bridge.js
+++ b/turbolinks/src/main/assets/js/turbolinks_bridge.js
@@ -53,8 +53,8 @@ TLWebView.prototype = {
     // Adapter
     // -----------------------------------------------------------------------
 
-    visitProposedToLocationWithAction: function(location, action) {
-        TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action);
+    visitProposedToLocationWithAction: function(location, action, target) {
+        TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action, target.outerHTML);
     },
 
     visitStarted: function(visit) {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
@@ -46,5 +46,5 @@ public interface TurbolinksAdapter {
      * @param location URL to be visited.
      * @param action Whether to treat the request as an advance (navigating forward) or a replace (back).
      */
-    void visitProposedToLocationWithAction(String location, String action);
+    void visitProposedToLocationWithAction(String location, String action, String target);
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -116,7 +116,7 @@ public class TurbolinksSession {
                 if ((currentOverrideTime - previousOverrideTime) > 500) {
                     previousOverrideTime = currentOverrideTime;
                     TurbolinksLog.d("Overriding load: " + location);
-                    visitProposedToLocationWithAction(location, ACTION_ADVANCE);
+                    visitProposedToLocationWithAction(location, ACTION_ADVANCE, null);
                 }
 
                 return true;
@@ -334,10 +334,10 @@ public class TurbolinksSession {
      */
     @SuppressWarnings("unused")
     @android.webkit.JavascriptInterface
-    public void visitProposedToLocationWithAction(String location, String action) {
+    public void visitProposedToLocationWithAction(String location, String action, String target) {
         TurbolinksLog.d("visitProposedToLocationWithAction called");
 
-        turbolinksAdapter.visitProposedToLocationWithAction(location, action);
+        turbolinksAdapter.visitProposedToLocationWithAction(location, action, target);
     }
 
     /**

--- a/turbolinks/src/test/java/com/basecamp/turbolinks/TurbolinkSessionTest.java
+++ b/turbolinks/src/test/java/com/basecamp/turbolinks/TurbolinkSessionTest.java
@@ -114,9 +114,9 @@ public class TurbolinkSessionTest extends BaseTest {
     public void visitProposedToLocationWithActionCallsAdapter() {
         turbolinksSession.activity(activity)
             .adapter(adapter);
-        turbolinksSession.visitProposedToLocationWithAction(LOCATION, TurbolinksSession.ACTION_ADVANCE);
+        turbolinksSession.visitProposedToLocationWithAction(LOCATION, TurbolinksSession.ACTION_ADVANCE, "<a href='/' />");
 
-        verify(adapter).visitProposedToLocationWithAction(any(String.class), any(String.class));
+        verify(adapter).visitProposedToLocationWithAction(any(String.class), any(String.class), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
This PR is a continuation of my [previously opened issue](https://github.com/turbolinks/turbolinks-android/issues/6). Working in conjunction with [this PR on Turbolinks JS](https://github.com/turbolinks/turbolinks/pull/33), this exposes the clicked HTML DOM node that triggered the initial navigation event.

The goal is explained in detail in the mentioned issue, but here is a quick summary.

> The purpose of exposing an HTML element to the adapter is to keep more information/logic on the server. This is accomplished by embedding metadata in the node itself to provide context for a native client.
>
> For example, setting `data-screen-title` on an anchor could be interpreted on the client to set the title of the next screen, before any page loading begins! Or setting `data-type-form` to have the client always use the same activity or view controller with form behavior, implemented with native Java or Swift/Objective-C.

Right now the node is passed as a simple `String`. There is potential room for future enchantment by making this a "real" DOM node. However, I'm not sure of the right way to accomplish this in Android. Any help/feedback would be greatly appreciated.