### PR TITLE
Inject custom Javascript files

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ TurbolinksSession.getDefault().addJavascriptInterface(this, "MyCustomJavascriptI
 
 The Java object being passed in can be anything, as long as it has at least one method annotated with `@android.webkit.JavascriptInterface`. Names of interfaces must be unique, or they will be overwritten in the library's map.
 
+### Custom Javascript Files
+
+You can also inject custom Javascript when the page finishes loading. This is useful when adding handlers for Javascript events, such as `turbolinks:request-start`.
+
+For example, you can add `custom.js` to `assets/js/custom.js` and inject it in your `TurbolinksAdapter` implementation.
+
+```java
+@Override
+public void onPageFinished() {
+    TurbolinksSession session = TurbolinksSession.getDefault(activity);
+    WebView webView = session.getWebView();
+    TurbolinksJavascriptInjector.injectJavascript(session, this, webView, "js/custom.js");
+}
+```
+
 ## Running the Demo App
 
 A demo app is bundled with the library, and works in two parts:

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Handler;
-import android.util.Base64;
-import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -15,14 +13,10 @@ import com.google.gson.GsonBuilder;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 
 class TurbolinksHelper {
-    private static String scriptInjectionFormat = "(function(){var parent = document.getElementsByTagName('head').item(0);var script = document.createElement('script');script.type = 'text/javascript';script.innerHTML = window.atob('%s');parent.appendChild(script);return true;})()";
-
     // ---------------------------------------------------
     // Package public
     // ---------------------------------------------------
@@ -55,47 +49,6 @@ class TurbolinksHelper {
             return uri.toURL().toString();
         } catch (Exception e) {
             return null;
-        }
-    }
-
-    /**
-     * <p>Gets the base64-encoded string of a local asset file (typically a Javascript or HTML file)</p>
-     *
-     * @param context  An activity context.
-     * @param filePath Local file path relative to the main/src directory.
-     * @return A base-64 encoded string of the file contents.
-     * @throws IOException Typically if a file cannot be found or read in.
-     */
-    static String getContentFromAssetFile(Context context, String filePath) throws IOException {
-        InputStream inputStream = context.getAssets().open(filePath);
-        byte[] buffer = new byte[inputStream.available()];
-        inputStream.read(buffer);
-        inputStream.close();
-        return Base64.encodeToString(buffer, Base64.NO_WRAP);
-    }
-
-    /**
-     * <p>Injects Javascript into the webView.</p>
-     *
-     * @param turbolinksSession The TurbolinksSession.
-     * @param context           Any Android context.
-     * @param webView           The shared webView.
-     */
-    static void injectTurbolinksBridge(final TurbolinksSession turbolinksSession, Context context, WebView webView) {
-        try {
-            String script = TurbolinksHelper.getContentFromAssetFile(context, "js/turbolinks_bridge.js");
-            String jsCall = String.format(scriptInjectionFormat, script);
-
-            webView.evaluateJavascript(jsCall, new ValueCallback<String>() {
-                @Override
-                public void onReceiveValue(String s) {
-                    if (turbolinksSession != null) {
-                        turbolinksSession.turbolinksBridgeInjected = Boolean.parseBoolean(s);
-                    }
-                }
-            });
-        } catch (IOException e) {
-            TurbolinksLog.e("Error injecting script file into webview: " + e.toString());
         }
     }
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksJavascriptInjector.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksJavascriptInjector.java
@@ -1,0 +1,74 @@
+package com.basecamp.turbolinks;
+
+import android.content.Context;
+import android.util.Base64;
+import android.webkit.ValueCallback;
+import android.webkit.WebView;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class TurbolinksJavascriptInjector {
+    private static String scriptInjectionFormat = "(function(){var parent = document.getElementsByTagName('head').item(0);var script = document.createElement('script');script.type = 'text/javascript';script.innerHTML = window.atob('%s');parent.appendChild(script);return true;})()";
+
+    // ---------------------------------------------------
+    // Public
+    // ---------------------------------------------------
+
+    /**
+     * <p>Injects Javascript into the webView.</p>
+     *
+     * @param turbolinksSession The TurbolinksSession.
+     * @param context           Any Android context.
+     * @param webView           The shared webView.
+     * @param filePath          Local file path relative to the main/src directory.
+     */
+    public static void injectJavascript(final TurbolinksSession turbolinksSession, Context context, WebView webView, String filePath) {
+        try {
+            String script = TurbolinksJavascriptInjector.getContentFromAssetFile(context, filePath);
+            String jsCall = String.format(scriptInjectionFormat, script);
+
+            webView.evaluateJavascript(jsCall, new ValueCallback<String>() {
+                @Override
+                public void onReceiveValue(String s) {
+                    if (turbolinksSession != null) {
+                        turbolinksSession.turbolinksBridgeInjected = Boolean.parseBoolean(s);
+                    }
+                }
+            });
+        } catch (IOException e) {
+            TurbolinksLog.e("Error injecting script file into webview: " + e.toString());
+        }
+    }
+
+    /**
+     * <p>Injects the Turbolinks bridge Javascript into the webView.</p>
+     *
+     * @param turbolinksSession The TurbolinksSession.
+     * @param context           Any Android context.
+     * @param webView           The shared webView.
+     */
+    public static void injectTurbolinksBridge(final TurbolinksSession turbolinksSession, Context context, WebView webView) {
+        TurbolinksJavascriptInjector.injectJavascript(turbolinksSession, context, webView, "js/turbolinks_bridge.js");
+    }
+
+    // ---------------------------------------------------
+    // Private
+    // ---------------------------------------------------
+
+    /**
+     * <p>Gets the base64-encoded string of a local asset file (typically a Javascript or HTML file)</p>
+     *
+     * @param context  An activity context.
+     * @param filePath Local file path relative to the main/src directory.
+     * @return A base-64 encoded string of the file contents.
+     * @throws IOException Typically if a file cannot be found or read in.
+     */
+    private static String getContentFromAssetFile(Context context, String filePath) throws IOException {
+        InputStream inputStream = context.getAssets().open(filePath);
+        byte[] buffer = new byte[inputStream.available()];
+        inputStream.read(buffer);
+        inputStream.close();
+        return Base64.encodeToString(buffer, Base64.NO_WRAP);
+    }
+}

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -86,7 +86,7 @@ public class TurbolinksSession {
             @Override
             public void onPageFinished(WebView view, String location) {
                 if (!turbolinksBridgeInjected) {
-                    TurbolinksHelper.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
+                    TurbolinksJavascriptInjector.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
                     turbolinksAdapter.onPageFinished();
 
                     TurbolinksLog.d("Page finished: " + location);


### PR DESCRIPTION
This PR enables developers to easily inject custom Javascript in to the WebView managed by Turbolinks.

All injection logic was first extracted to a new, public class, `TurbolinksJavascriptInjector`. This exposes the original method to inject the Turbolinks bridge and adds a new one. The new method takes in the path of the Javascript file to be injected.

As noted in the update to the README, this creates an opportunity to add Javascript event handlers. A direct use-case of this is to [set custom HTTP headers for each Turbolinks request](https://github.com/turbolinks/turbolinks#setting-custom-http-headers).