### PR TITLE
Re-inject the Turbolinks bridge on any full page load

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -50,7 +50,7 @@ ext {
 
     libraryName = 'Turbolinks Android'
     libraryDescription = 'Turbolinks for Android'
-    libraryVersion = '1.0.0'
+    libraryVersion = '1.0.1-beta'
 
     siteUrl = 'https://github.com/basecamp/turbolinks-android'
     gitUrl = 'https://github.com/basecamp/turbolinks-android.git'

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Handler;
 import android.util.Base64;
-import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -83,17 +82,8 @@ class TurbolinksHelper {
      */
     static void injectTurbolinksBridge(final TurbolinksSession turbolinksSession, Context context, WebView webView) {
         try {
-            String script = TurbolinksHelper.getContentFromAssetFile(context, "js/turbolinks_bridge.js");
-            String jsCall = String.format(scriptInjectionFormat, script);
-
-            webView.evaluateJavascript(jsCall, new ValueCallback<String>() {
-                @Override
-                public void onReceiveValue(String s) {
-                    if (turbolinksSession != null) {
-                        turbolinksSession.turbolinksBridgeInjected = Boolean.parseBoolean(s);
-                    }
-                }
-            });
+            String jsCall = String.format(scriptInjectionFormat, TurbolinksHelper.getContentFromAssetFile(context, "js/turbolinks_bridge.js"));
+            runJavascriptRaw(context, webView, jsCall);
         } catch (IOException e) {
             TurbolinksLog.e("Error injecting script file into webview: " + e.toString());
         }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -90,14 +90,12 @@ public class TurbolinksSession {
                 webView.evaluateJavascript(jsCall, new ValueCallback<String>() {
                     @Override
                     public void onReceiveValue(String s) {
-                        if (Boolean.parseBoolean(s)) {
-                            if (!bridgeInjectionInProgress) {
-                                bridgeInjectionInProgress = true;
-                                TurbolinksHelper.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
-                                TurbolinksLog.d("Bridge injected");
+                        if (Boolean.parseBoolean(s) && !bridgeInjectionInProgress) {
+                            bridgeInjectionInProgress = true;
+                            TurbolinksHelper.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
+                            TurbolinksLog.d("Bridge injected");
 
-                                turbolinksAdapter.onPageFinished();
-                            }
+                            turbolinksAdapter.onPageFinished();
                         }
                     }
                 });

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -13,6 +13,7 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.ValueCallback;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -84,13 +85,26 @@ public class TurbolinksSession {
             }
 
             @Override
-            public void onPageFinished(WebView view, String location) {
-                if (!turbolinksBridgeInjected) {
-                    TurbolinksHelper.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
-                    turbolinksAdapter.onPageFinished();
+            public void onPageFinished(WebView view, final String location) {
+                String jsCall = "window.webView != null";
 
-                    TurbolinksLog.d("Page finished: " + location);
-                }
+                TurbolinksLog.d("onPageFinished");
+
+                webView.evaluateJavascript(jsCall, new ValueCallback<String>() {
+                    @Override
+                    public void onReceiveValue(String s) {
+                        boolean webViewExists = Boolean.parseBoolean(s);
+                        TurbolinksLog.d("Javascript webView exists: " + webViewExists);
+
+                        if (!webViewExists) {
+                            TurbolinksHelper.injectTurbolinksBridge(TurbolinksSession.this, applicationContext, webView);
+                            turbolinksAdapter.onPageFinished();
+
+                            TurbolinksLog.d("Page finished: " + location);
+                        }
+                    }
+                });
+
             }
 
             /**

--- a/turbolinks/src/test/java/com/basecamp/turbolinks/TurbolinkSessionTest.java
+++ b/turbolinks/src/test/java/com/basecamp/turbolinks/TurbolinkSessionTest.java
@@ -231,12 +231,12 @@ public class TurbolinkSessionTest extends BaseTest {
     public void resetToColdBoot() {
         turbolinksSession.activity(activity)
             .adapter(adapter);
-        turbolinksSession.turbolinksBridgeInjected = true;
+        turbolinksSession.bridgeInjectionInProgress = true;
         turbolinksSession.turbolinksIsReady = true;
         turbolinksSession.coldBootInProgress = false;
         turbolinksSession.resetToColdBoot();
 
-        assertThat(turbolinksSession.turbolinksBridgeInjected).isFalse();
+        assertThat(turbolinksSession.bridgeInjectionInProgress).isFalse();
         assertThat(turbolinksSession.turbolinksIsReady).isFalse();
         assertThat(turbolinksSession.coldBootInProgress).isFalse();
     }


### PR DESCRIPTION
I discovered a bug where a full page load could potentially break the webView session.

After the Turbolinks Javascript bridge is injected the first time, we weren't properly handling the case where another full page load would happen after that (e.g., a form submission + full page load). In such cases, the webView wouldn't have our Javascript bridge injected, and TL would effectively be dead until app restart.

This fix adds a runtime check to look for our bridge object (`window.webView`) instead of making the bad assumption that once injected it would be set. If the bridge object doesn't exist during a full page load (detected during `onPageFinished`), we re-inject the bridge at that time.