### PR TITLE
Automatic screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ This is a callback from Turbolinks telling you that a change has been detected i
 
 The library will automatically fall back to cold booting the location (which it must do since resources have been changed) and then will notify you via this callback that the page was invalidated. This is an opportunity for you to clean up any UI state that you might have lingering around that may no longer be valid (like a screenshot, title data, etc.)
 
+### Overriding Default TurbolinksSession Settings
+There are some optional features in TurbolinksSession that are enabled by default.
+
+#### Pull To Refresh
+Refreshes the TurbolinksView when a user swipes down from the top of the view.
+To disable simply call:
+```java
+turbolinksSession.setPullToRefreshEnabled(false);
+```
+
 ### Custom Instance(s) of TurbolinksSession
 
 We provide a single, reusable instance of TurbolinksSession that you can access through this convenience method:

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 buildscript {
+    ext.supportLibVersion = '24.0.0'
+
     repositories {
         jcenter()
     }
@@ -13,12 +15,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 4
         versionName "1.0.2"
     }
@@ -32,8 +34,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'org.apache.commons:commons-lang3:3.4'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
     compile 'com.google.code.gson:gson:2.3.1'
+    compile 'org.apache.commons:commons-lang3:3.4'
 
     testCompile 'org.assertj:assertj-core:1.7.0'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
@@ -1,0 +1,13 @@
+package com.basecamp.turbolinks;
+
+/**
+ * <p>Defines a callback for determining whether or not a child view can scroll up.</p>
+ */
+public interface CanScrollUpCallback {
+    /**
+     *<p>Used to determine whether or not a child view can scroll up.</p>
+     *
+     * @return True if the child can scroll up. False otherwise.
+     */
+    boolean canChildScrollUp();
+}

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -505,7 +505,7 @@ public class TurbolinksSession {
                  */
                 if (turbolinksIsReady && TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
                     TurbolinksLog.d("Hiding progress view for visitIdentifier: " + visitIdentifier + ", currentVisitIdentifier: " + currentVisitIdentifier);
-                    turbolinksView.removeProgressView();
+                    turbolinksView.hideProgress();
                     progressView = null;
                 }
             }
@@ -561,7 +561,7 @@ public class TurbolinksSession {
             public void run() {
                 TurbolinksLog.d("Error instantiating turbolinks_bridge.js - resetting to cold boot.");
                 resetToColdBoot();
-                turbolinksView.removeProgressView();
+                turbolinksView.hideProgress();
             }
         });
     }
@@ -716,7 +716,7 @@ public class TurbolinksSession {
         }
 
         // Executed from here to account for progress indicator delay
-        turbolinksView.showProgressView(progressView, progressIndicator, progressIndicatorDelay);
+        turbolinksView.showProgress(progressView, progressIndicator, progressIndicatorDelay);
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -344,10 +344,15 @@ public class TurbolinksSession {
      */
     @SuppressWarnings("unused")
     @android.webkit.JavascriptInterface
-    public void visitProposedToLocationWithAction(String location, String action) {
+    public void visitProposedToLocationWithAction(final String location, final String action) {
         TurbolinksLog.d("visitProposedToLocationWithAction called");
 
-        turbolinksAdapter.visitProposedToLocationWithAction(location, action);
+        TurbolinksHelper.runOnMainThread(applicationContext, new Runnable() {
+            @Override
+            public void run() {
+                turbolinksAdapter.visitProposedToLocationWithAction(location, action);
+            }
+        });
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -35,6 +35,7 @@ public class TurbolinksSession {
     boolean coldBootInProgress;
     boolean restoreWithCachedSnapshot;
     boolean turbolinksIsReady; // Script finished and TL fully instantiated
+    boolean screenshotsEnabled;
     int progressIndicatorDelay;
     long previousOverrideTime;
     Activity activity;
@@ -76,6 +77,7 @@ public class TurbolinksSession {
         }
 
         this.applicationContext = context.getApplicationContext();
+        this.screenshotsEnabled = true;
         this.webView = TurbolinksHelper.createWebView(applicationContext);
         this.webView.addJavascriptInterface(this, JAVASCRIPT_INTERFACE_NAME);
         this.webView.setWebViewClient(new WebViewClient() {
@@ -245,7 +247,7 @@ public class TurbolinksSession {
      */
     public TurbolinksSession view(TurbolinksView turbolinksView) {
         this.turbolinksView = turbolinksView;
-        this.turbolinksView.attachWebView(webView);
+        this.turbolinksView.attachWebView(webView, screenshotsEnabled);
 
         return this;
     }
@@ -645,6 +647,16 @@ public class TurbolinksSession {
      */
     public void setDebugLoggingEnabled(boolean enabled) {
         TurbolinksLog.setDebugLoggingEnabled(enabled);
+    }
+
+    /**
+     * <p>Determines whether screenshots are displayed (instead of a progress view) when resuming
+     * an activity. Default is true.</p>
+     *
+     * @param enabled If true automatic screenshotting is enabled.
+     */
+    public void setScreenshotsEnabled(boolean enabled) {
+        screenshotsEnabled = enabled;
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
@@ -1,0 +1,51 @@
+package com.basecamp.turbolinks;
+
+import android.content.Context;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.AttributeSet;
+
+/**
+ * <p>Custom SwipeRefreshLayout for Turbolinks.</p>
+ */
+public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
+    private CanScrollUpCallback callback;
+
+    /**
+     * <p>Constructor to match SwipeRefreshLayout</p>
+     *
+     * @param context Refer to SwipeRefreshLayout
+     */
+    public TurbolinksSwipeRefreshLayout(Context context) {
+        super(context);
+    }
+
+    /**
+     * <p>Constructor to match SwipeRefreshLayout</p>
+     *
+     * @param context Refer to SwipeRefreshLayout
+     * @param attrs Refer to SwipeRefreshLayout
+     */
+    public TurbolinksSwipeRefreshLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /**
+     * <p>Overridden from SwipeRefreshLayout. Uses a custom callback.</p>
+     * <p>If the custom callback is null, it falls back to the parent canChildScrollUp()</p>
+     *
+     * @return True if the child view can scroll up. False otherwise.
+     */
+    @Override
+    public boolean canChildScrollUp() {
+        if (callback != null) { return callback.canChildScrollUp(); }
+        return super.canChildScrollUp();
+    }
+
+    /**
+     * <p>Sets the callback to be used in canChildScrollUp().</p>
+     * <p>See canChildScrollUp() to see how it's used.</p>
+     *
+     * @param callback The custom callback to be set
+     */
+    public void setCallback(CanScrollUpCallback callback) { this.callback = callback; }
+}

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -19,6 +20,7 @@ import android.widget.ImageView;
  */
 public class TurbolinksView extends FrameLayout {
     private View progressView = null;
+    private TurbolinksSession turbolinksSession;
     private ImageView screenshotView = null;
     private int screenshotOrientation = 0;
 
@@ -119,26 +121,42 @@ public class TurbolinksView extends FrameLayout {
     }
 
     /**
-     * <p>Attach the shared webView to the TurbolinksView.</p>
+     * <p>Attach the swipeRefreshLayout, which contains the shared webView, to the TurbolinksView.</p>
      *
      * @param webView The shared webView.
+     * @param swipeRefreshLayout parent view of webView
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
+     * @param pullToRefreshEnabled Indicates whether pull to refresh is enabled for the current session.
      */
-    void attachWebView(WebView webView, boolean screenshotsEnabled) {
-        if (webView.getParent() == this) return;
+    void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled, boolean pullToRefreshEnabled) {
+        if (swipeRefreshLayout.getParent() == this) return;
 
-        if (webView.getParent() instanceof TurbolinksView) {
-            TurbolinksView parent = (TurbolinksView) webView.getParent();
+        swipeRefreshLayout.setEnabled(pullToRefreshEnabled);
+
+        if (swipeRefreshLayout.getParent() instanceof TurbolinksView) {
+            TurbolinksView parent = (TurbolinksView) swipeRefreshLayout.getParent();
             if (screenshotsEnabled) parent.screenshotView();
-            parent.removeView(webView);
+            parent.removeView(swipeRefreshLayout);
         }
+
+        removeChildViewFromSwipeRefresh(webView);
 
         // Set the webview background to match the container background
         if (getBackground() instanceof ColorDrawable) {
             webView.setBackgroundColor(((ColorDrawable) getBackground()).getColor());
         }
 
-        addView(webView, 0);
+        swipeRefreshLayout.addView(webView);
+        addView(swipeRefreshLayout, 0);
+    }
+
+    /**
+     * Used to remove the child WebView from the swipeRefreshLayout.
+     * @param child WebView that is child of swipeRefreshLayout
+     */
+    private void removeChildViewFromSwipeRefresh(View child) {
+        ViewGroup parent = (ViewGroup) child.getParent();
+        if (parent != null) { parent.removeView(child); }
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -129,11 +129,12 @@ public class TurbolinksView extends FrameLayout {
      * <p>Attach the shared webView to the TurbolinksView.</p>
      *
      * @param webView The shared webView.
+     * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
      */
-    void attachWebView(WebView webView) {
+    void attachWebView(WebView webView, boolean screenshotsEnabled) {
         ViewGroup parent = (ViewGroup) webView.getParent();
         if (parent != null && parent instanceof TurbolinksView) {
-            ((TurbolinksView) parent).screenshotView();
+            if (screenshotsEnabled) ((TurbolinksView) parent).screenshotView();
             parent.removeView(webView);
         }
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -125,6 +125,8 @@ public class TurbolinksView extends FrameLayout {
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
      */
     void attachWebView(WebView webView, boolean screenshotsEnabled) {
+        if (webView.getParent() == this) return;
+
         if (webView.getParent() instanceof TurbolinksView) {
             TurbolinksView parent = (TurbolinksView) webView.getParent();
             if (screenshotsEnabled) parent.screenshotView();

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -74,8 +74,11 @@ public class TurbolinksView extends FrameLayout {
     // ---------------------------------------------------
 
     /**
-     * <p>Detaches/attaches a progress view on top of the TurbolinksView to indicate the page is
-     * loading. Progress indicator is set to a specified delay before displaying -- a very short delay
+     * <p>Shows a progress view or a generated screenshot of the webview content (if available)
+     * on top of the webview. When advancing to a new url, this indicates that the page is still
+     * loading. When resuming an activity in the navigation stack, a screenshot is displayed while the
+     * webview is restoring its snapshot.</p>
+     * <p>Progress indicator is set to a specified delay before displaying -- a very short delay
      * (like 500 ms) can improve perceived loading time to the user.</p>
      *
      * @param progressView The progressView to display on top of TurbolinksView.
@@ -83,13 +86,13 @@ public class TurbolinksView extends FrameLayout {
      * @param delay The delay before showing the progressIndicator in the view. The default progress view
      *              is 500 ms.
      */
-    void showProgressView(final View progressView, final View progressIndicator, int delay) {
-        TurbolinksLog.d("showProgressView called");
+    void showProgress(final View progressView, final View progressIndicator, int delay) {
+        TurbolinksLog.d("showProgress called");
 
         // Don't show the progress view if a screenshot is available
         if (screenshotView != null) return;
 
-        removeProgressView();
+        hideProgress();
 
         this.progressView = progressView;
         progressView.setClickable(true);
@@ -107,10 +110,10 @@ public class TurbolinksView extends FrameLayout {
     }
 
     /**
-     * <p>Removes the progressView from the TurbolinksView. Ensures no exceptions are thrown where
-     * the progressView is already attached to another view.</p>
+     * <p>Removes the progress view and/or screenshot from the TurbolinksView, so the webview is
+     * visible underneath.</p>
      */
-    void removeProgressView() {
+    void hideProgress() {
         if (progressView != null) {
             removeView(progressView);
         }


### PR DESCRIPTION
This adds `WebView` screenshotting as a new, default feature. When restoring/restarting an `Activity` in the navigation stack, a screenshot of its prior contents will be displayed until the DOM snapshot is restored. This provides the visual illusion that the restarted activity's contents are immediately available, and avoids a brief flicker before showing the DOM snapshot.

Screenshotting is enabled by default, but can be configured for the `TurbolinksSession`. To disable this default behavior for the duration of the sesion, simply call the following:

```
session.setScreenshotsEnabled(false);
```