### PR TITLE
Pull to Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    'com.basecamp:turbolinks:1.0.1'
+    'com.basecamp:turbolinks:1.0.2'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Some things to keep in mind if you create your own instance of TurbolinksSession
 
 You'll need to weigh the benefits and complexities of those options, but the bottom line is that you'll want to carefully manage the lifecycle of your Turbolinks instance(s).
 
-### Custom TurbolinksSession Settings
+### Overriding Default TurbolinksSession Settings
 There are some optional features in TurbolinksSession that are enabled by default. 
 
 #### Pull To Refresh

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ This is a callback from Turbolinks telling you that a change has been detected i
 
 The library will automatically fall back to cold booting the location (which it must do since resources have been changed) and then will notify you via this callback that the page was invalidated. This is an opportunity for you to clean up any UI state that you might have lingering around that may no longer be valid (like a screenshot, title data, etc.)
 
+### Overriding Default TurbolinksSession Settings
+There are some optional features in TurbolinksSession that are enabled by default.
+
+#### Pull To Refresh
+Refreshes the TurbolinksView when a user swipes down from the top of the view.
+To disable simply call:
+```java
+turbolinksSession.setPullToRefreshEnabled(false);
+```
+
 ### Custom Instance(s) of TurbolinksSession
 
 We provide a single, reusable instance of TurbolinksSession that you can access through this convenience method:
@@ -170,16 +180,6 @@ Some things to keep in mind if you create your own instance of TurbolinksSession
   - A custom object that extends `Application`
 
 You'll need to weigh the benefits and complexities of those options, but the bottom line is that you'll want to carefully manage the lifecycle of your Turbolinks instance(s).
-
-### Overriding Default TurbolinksSession Settings
-There are some optional features in TurbolinksSession that are enabled by default. 
-
-#### Pull To Refresh
-Refreshes the TurbolinksView when a user swipes down from the top of the view. 
-To disable simply call:
-```java
-turbolinksSession.setPullToRefreshEnabled(false);
-```
 
 ### Custom Progress View
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -19,8 +19,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 23
-        versionCode 3
-        versionName "1.0.1"
+        versionCode 4
+        versionName "1.0.2"
     }
     buildTypes {
         release {
@@ -50,7 +50,7 @@ ext {
 
     libraryName = 'Turbolinks Android'
     libraryDescription = 'Turbolinks for Android'
-    libraryVersion = '1.0.1'
+    libraryVersion = '1.0.2'
 
     siteUrl = 'https://github.com/basecamp/turbolinks-android'
     gitUrl = 'https://github.com/basecamp/turbolinks-android.git'

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 buildscript {
+    ext.supportLibVersion = '23.4.0'
+
     repositories {
         jcenter()
     }
@@ -34,6 +36,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'com.google.code.gson:gson:2.3.1'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
 
     testCompile 'org.assertj:assertj-core:1.7.0'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 buildscript {
-    ext.supportLibVersion = '23.4.0'
+    ext.supportLibVersion = '24.0.0'
 
     repositories {
         jcenter()
@@ -15,12 +15,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 4
         versionName "1.0.2"
     }
@@ -34,9 +34,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.google.code.gson:gson:2.3.1'
     compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'org.apache.commons:commons-lang3:3.4'
 
     testCompile 'org.assertj:assertj-core:1.7.0'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
@@ -1,0 +1,5 @@
+package com.basecamp.turbolinks;
+
+public interface CanScrollUpCallback {
+    boolean canChildScrollUp();
+}

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/CanScrollUpCallback.java
@@ -1,5 +1,13 @@
 package com.basecamp.turbolinks;
 
+/**
+ * <p>Defines a callback for determining whether or not a child view can scroll up.</p>
+ */
 public interface CanScrollUpCallback {
+    /**
+     *<p>Used to determine whether or not a child view can scroll up.</p>
+     *
+     * @return True if the child can scroll up. False otherwise.
+     */
     boolean canChildScrollUp();
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -37,6 +37,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
     boolean restoreWithCachedSnapshot;
     boolean turbolinksIsReady; // Script finished and TL fully instantiated
     boolean screenshotsEnabled;
+    boolean pullToRefreshEnabled;
     int progressIndicatorDelay;
     long previousOverrideTime;
     Activity activity;
@@ -79,6 +80,10 @@ public class TurbolinksSession implements CanScrollUpCallback {
             throw new IllegalArgumentException("Context must not be null.");
         }
 
+        this.applicationContext = context.getApplicationContext();
+        this.screenshotsEnabled = true;
+        this.pullToRefreshEnabled = true;
+
         this.swipeRefreshLayout = new TurbolinksSwipeRefreshLayout(context, null);
         this.swipeRefreshLayout.setCallback(this);
         this.swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
@@ -88,8 +93,6 @@ public class TurbolinksSession implements CanScrollUpCallback {
             }
         });
 
-        this.applicationContext = context.getApplicationContext();
-        this.screenshotsEnabled = true;
         this.webView = TurbolinksHelper.createWebView(applicationContext);
         this.webView.addJavascriptInterface(this, JAVASCRIPT_INTERFACE_NAME);
         this.webView.setWebViewClient(new WebViewClient() {
@@ -259,7 +262,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      */
     public TurbolinksSession view(TurbolinksView turbolinksView) {
         this.turbolinksView = turbolinksView;
-        this.turbolinksView.attachWebView(webView, swipeRefreshLayout, screenshotsEnabled);
+        this.turbolinksView.attachWebView(webView, swipeRefreshLayout, screenshotsEnabled, pullToRefreshEnabled);
 
         return this;
     }
@@ -675,6 +678,16 @@ public class TurbolinksSession implements CanScrollUpCallback {
      */
     public void setScreenshotsEnabled(boolean enabled) {
         screenshotsEnabled = enabled;
+    }
+
+    /**
+     * <p>Determines whether WebViews can be refreshed by pulling/swiping from the top
+     * of the WebView. Default is true.</p>
+     *
+     * @param enabled If true pulling to refresh the WebView is enabled
+     */
+    public void setPullToRefreshEnabled(boolean enabled) {
+        pullToRefreshEnabled = enabled;
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -796,6 +796,15 @@ public class TurbolinksSession implements CanScrollUpCallback {
         }
     }
 
+    // ---------------------------------------------------
+    // Interfaces
+    // ---------------------------------------------------
+
+    /**
+     * <p>Determines if the user can scroll up, or if the WebView is at the top</p>
+     *
+     * @return True if the WebView can be scrolled up. False if the WebView is at the top.
+     */
     @Override
     public boolean canChildScrollUp() {
         return this.webView.getScrollY() > 0;

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -463,6 +463,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
                 @Override
                 public void run() {
                     turbolinksAdapter.visitCompleted();
+                    swipeRefreshLayout.setRefreshing(false);
                 }
             });
         }
@@ -733,7 +734,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
 
     /**
      * <p>Convenience method to simply revisit the current location in the TurbolinksSession. Useful
-     * so that different visit logic can be wrapped around this call in {@link #visit} or
+     * so that different visit logic can be wrappered around this call in {@link #visit} or
      * {@link #setTurbolinksIsReady(boolean)}</p>
      */
     private void visitCurrentLocationWithTurbolinks() {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -80,7 +80,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
         }
 
         this.swipeRefreshLayout = new TurbolinksSwipeRefreshLayout(context, null);
-        this.swipeRefreshLayout.setCanScrollUpCallback(this);
+        this.swipeRefreshLayout.setCallback(this);
         this.swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
@@ -1,0 +1,29 @@
+package com.basecamp.turbolinks;
+
+import android.content.Context;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.AttributeSet;
+
+public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
+
+    private CanScrollUpCallback callback;
+
+    public TurbolinksSwipeRefreshLayout(Context context) {
+        super(context);
+    }
+
+    public TurbolinksSwipeRefreshLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean canChildScrollUp() {
+        if (callback != null) {
+            return callback.canChildScrollUp();
+        }
+        return super.canChildScrollUp();
+    }
+
+    public void setCallback(CanScrollUpCallback callback) { this.callback = callback; }
+
+}

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
@@ -4,25 +4,48 @@ import android.content.Context;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 
+/**
+ * <p>Custom SwipeRefreshLayout for Turbolinks.</p>
+ */
 public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
     private CanScrollUpCallback callback;
 
+    /**
+     * <p>Constructor to match SwipeRefreshLayout</p>
+     *
+     * @param context Refer to SwipeRefreshLayout
+     */
     public TurbolinksSwipeRefreshLayout(Context context) {
         super(context);
     }
 
+    /**
+     * <p>Constructor to match SwipeRefreshLayout</p>
+     *
+     * @param context Refer to SwipeRefreshLayout
+     * @param attrs Refer to SwipeRefreshLayout
+     */
     public TurbolinksSwipeRefreshLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
+    /**
+     * <p>Overridden from SwipeRefreshLayout. Uses a custom callback.</p>
+     * <p>If the custom callback is null, it falls back to the parent canChildScrollUp()</p>
+     *
+     * @return True if the child view can scroll up. False otherwise.
+     */
     @Override
     public boolean canChildScrollUp() {
-        if (callback != null) {
-            return callback.canChildScrollUp();
-        }
+        if (callback != null) { return callback.canChildScrollUp(); }
         return super.canChildScrollUp();
     }
 
+    /**
+     * <p>Sets the callback to be used in canChildScrollUp().</p>
+     * <p>See canChildScrollUp() to see how it's used.</p>
+     *
+     * @param callback The custom callback to be set
+     */
     public void setCallback(CanScrollUpCallback callback) { this.callback = callback; }
-
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
@@ -5,7 +5,6 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 
 public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
-
     private CanScrollUpCallback callback;
 
     public TurbolinksSwipeRefreshLayout(Context context) {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -8,7 +8,6 @@ import android.graphics.Canvas;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Handler;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -136,7 +135,7 @@ public class TurbolinksView extends FrameLayout {
             parent.removeView(swipeRefreshLayout);
         }
 
-        removeChildView(webView);
+        removeChildViewFromSwipeRefresh(webView);
 
         // Set the webview background to match the container background
         if (getBackground() instanceof ColorDrawable) {
@@ -147,7 +146,7 @@ public class TurbolinksView extends FrameLayout {
         addView(swipeRefreshLayout, 0);
     }
 
-    private void removeChildView(View child) {
+    private void removeChildViewFromSwipeRefresh(View child) {
         ViewGroup parent = (ViewGroup) child.getParent();
         if (parent != null) {
             parent.removeView(child);

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -15,7 +15,7 @@ import android.widget.FrameLayout;
 /**
  * <p>The custom view to add to your activity layout.</p>
  */
-public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
+public class TurbolinksView extends FrameLayout {
     private View progressView = null;
     private TurbolinksSession turbolinksSession;
 
@@ -114,10 +114,8 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
      * @param webView The shared webView.
      */
     void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout) {
-        ViewGroup parent = (ViewGroup) swipeRefreshLayout.getParent();
-        if (parent != null) {
-            parent.removeView(swipeRefreshLayout);
-        }
+        removeChildView(swipeRefreshLayout);
+        removeChildView(webView);
 
         // Set the webview background to match the container background
         if (getBackground() instanceof ColorDrawable) {
@@ -128,8 +126,10 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
         addView(swipeRefreshLayout, 0);
     }
 
-    @Override
-    public boolean canChildScrollUp() {
-        return this.getScrollY() > 0;
+    private void removeChildView(View child) {
+        ViewGroup parent = (ViewGroup) child.getParent();
+        if (parent != null) {
+            parent.removeView(child);
+        }
     }
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -124,6 +124,7 @@ public class TurbolinksView extends FrameLayout {
      * <p>Attach the shared webView to the TurbolinksView.</p>
      *
      * @param webView The shared webView.
+     * @param swipeRefreshLayout parent view of webView
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
      */
     void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled) {

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -36,7 +36,7 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
      * <p>Constructor to match FrameLayout.</p>
      *
      * @param context Refer to FrameLayout.
-     * @param attrs   Refer to FrameLayout.
+     * @param attrs Refer to FrameLayout.
      */
     public TurbolinksView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -45,8 +45,8 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
     /**
      * <p>Constructor to match FrameLayout.</p>
      *
-     * @param context      Refer to FrameLayout.
-     * @param attrs        Refer to FrameLayout.
+     * @param context Refer to FrameLayout.
+     * @param attrs Refer to FrameLayout.
      * @param defStyleAttr Refer to FrameLayout.
      */
     public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr) {
@@ -56,10 +56,10 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
     /**
      * <p>Constructor to match FrameLayout.</p>
      *
-     * @param context      Refer to FrameLayout.
-     * @param attrs        Refer to FrameLayout.
+     * @param context Refer to FrameLayout.
+     * @param attrs Refer to FrameLayout.
      * @param defStyleAttr Refer to FrameLayout.
-     * @param defStyleRes  Refer to FrameLayout.
+     * @param defStyleRes Refer to FrameLayout.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -75,10 +75,10 @@ public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
      * loading. Progress indicator is set to a specified delay before displaying -- a very short delay
      * (like 500 ms) can improve perceived loading time to the user.</p>
      *
-     * @param progressView      The progressView to display on top of TurbolinksView.
+     * @param progressView The progressView to display on top of TurbolinksView.
      * @param progressIndicator The progressIndicator to display in the view.
-     * @param delay             The delay before showing the progressIndicator in the view. The default progress view
-     *                          is 500 ms.
+     * @param delay The delay before showing the progressIndicator in the view. The default progress view
+     *              is 500 ms.
      */
     void showProgressView(final View progressView, final View progressIndicator, int delay) {
         TurbolinksLog.d("showProgressView called");

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -121,16 +121,17 @@ public class TurbolinksView extends FrameLayout {
     }
 
     /**
-     * <p>Attach the shared webView to the TurbolinksView.</p>
+     * <p>Attach the swipeRefreshLayout, which contains the shared webView, to the TurbolinksView.</p>
      *
      * @param webView The shared webView.
      * @param swipeRefreshLayout parent view of webView
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
+     * @param pullToRefreshEnabled Indicates whether pull to refresh is enabled for the current session.
      */
     void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled, boolean pullToRefreshEnabled) {
         if (swipeRefreshLayout.getParent() == this) return;
 
-        if (!pullToRefreshEnabled) swipeRefreshLayout.setEnabled(false);
+        swipeRefreshLayout.setEnabled(pullToRefreshEnabled);
 
         if (swipeRefreshLayout.getParent() instanceof TurbolinksView) {
             TurbolinksView parent = (TurbolinksView) swipeRefreshLayout.getParent();
@@ -149,11 +150,13 @@ public class TurbolinksView extends FrameLayout {
         addView(swipeRefreshLayout, 0);
     }
 
+    /**
+     * Used to remove the child WebView from the swipeRefreshLayout.
+     * @param child WebView that is child of swipeRefreshLayout
+     */
     private void removeChildViewFromSwipeRefresh(View child) {
         ViewGroup parent = (ViewGroup) child.getParent();
-        if (parent != null) {
-            parent.removeView(child);
-        }
+        if (parent != null) { parent.removeView(child); }
     }
 
     /**

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -127,8 +127,10 @@ public class TurbolinksView extends FrameLayout {
      * @param swipeRefreshLayout parent view of webView
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
      */
-    void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled) {
+    void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled, boolean pullToRefreshEnabled) {
         if (swipeRefreshLayout.getParent() == this) return;
+
+        if (!pullToRefreshEnabled) swipeRefreshLayout.setEnabled(false);
 
         if (swipeRefreshLayout.getParent() instanceof TurbolinksView) {
             TurbolinksView parent = (TurbolinksView) swipeRefreshLayout.getParent();

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Handler;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,8 +15,9 @@ import android.widget.FrameLayout;
 /**
  * <p>The custom view to add to your activity layout.</p>
  */
-public class TurbolinksView extends FrameLayout {
+public class TurbolinksView extends FrameLayout implements CanScrollUpCallback {
     private View progressView = null;
+    private TurbolinksSession turbolinksSession;
 
     // ---------------------------------------------------
     // Constructors
@@ -34,7 +36,7 @@ public class TurbolinksView extends FrameLayout {
      * <p>Constructor to match FrameLayout.</p>
      *
      * @param context Refer to FrameLayout.
-     * @param attrs Refer to FrameLayout.
+     * @param attrs   Refer to FrameLayout.
      */
     public TurbolinksView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -43,8 +45,8 @@ public class TurbolinksView extends FrameLayout {
     /**
      * <p>Constructor to match FrameLayout.</p>
      *
-     * @param context Refer to FrameLayout.
-     * @param attrs Refer to FrameLayout.
+     * @param context      Refer to FrameLayout.
+     * @param attrs        Refer to FrameLayout.
      * @param defStyleAttr Refer to FrameLayout.
      */
     public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr) {
@@ -54,10 +56,10 @@ public class TurbolinksView extends FrameLayout {
     /**
      * <p>Constructor to match FrameLayout.</p>
      *
-     * @param context Refer to FrameLayout.
-     * @param attrs Refer to FrameLayout.
+     * @param context      Refer to FrameLayout.
+     * @param attrs        Refer to FrameLayout.
      * @param defStyleAttr Refer to FrameLayout.
-     * @param defStyleRes Refer to FrameLayout.
+     * @param defStyleRes  Refer to FrameLayout.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -73,10 +75,10 @@ public class TurbolinksView extends FrameLayout {
      * loading. Progress indicator is set to a specified delay before displaying -- a very short delay
      * (like 500 ms) can improve perceived loading time to the user.</p>
      *
-     * @param progressView The progressView to display on top of TurbolinksView.
+     * @param progressView      The progressView to display on top of TurbolinksView.
      * @param progressIndicator The progressIndicator to display in the view.
-     * @param delay The delay before showing the progressIndicator in the view. The default progress view
-     *              is 500 ms.
+     * @param delay             The delay before showing the progressIndicator in the view. The default progress view
+     *                          is 500 ms.
      */
     void showProgressView(final View progressView, final View progressIndicator, int delay) {
         TurbolinksLog.d("showProgressView called");
@@ -111,10 +113,10 @@ public class TurbolinksView extends FrameLayout {
      *
      * @param webView The shared webView.
      */
-    void attachWebView(WebView webView) {
-        ViewGroup parent = (ViewGroup) webView.getParent();
+    void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout) {
+        ViewGroup parent = (ViewGroup) swipeRefreshLayout.getParent();
         if (parent != null) {
-            parent.removeView(webView);
+            parent.removeView(swipeRefreshLayout);
         }
 
         // Set the webview background to match the container background
@@ -122,6 +124,12 @@ public class TurbolinksView extends FrameLayout {
             webView.setBackgroundColor(((ColorDrawable) getBackground()).getColor());
         }
 
-        addView(webView, 0);
+        swipeRefreshLayout.addView(webView);
+        addView(swipeRefreshLayout, 0);
+    }
+
+    @Override
+    public boolean canChildScrollUp() {
+        return this.getScrollY() > 0;
     }
 }


### PR DESCRIPTION
This adds Pull To Refresh functionality to Turbolinks. 

![2016_07_05_23_14_24_13_26_24](https://cloud.githubusercontent.com/assets/6729652/16617785/a3c6a7f4-437d-11e6-8a30-c7d155d728d8.gif)


The TurbolinksView view hierarchy would now be: 

![screen shot 2016-07-05 at 22 33 11](https://cloud.githubusercontent.com/assets/6729652/16600736/7fca5f8a-4300-11e6-827c-645a10af0943.png)

Pull to refresh can be disabled by calling: 
`turbolinksSession.setPullToRefreshEnabled(false)`

