### PR TITLE
Don't set progressView to null

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -529,7 +529,6 @@ public class TurbolinksSession implements CanScrollUpCallback {
                 if (turbolinksIsReady && TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
                     TurbolinksLog.d("Hiding progress view for visitIdentifier: " + visitIdentifier + ", currentVisitIdentifier: " + currentVisitIdentifier);
                     turbolinksView.hideProgress();
-                    progressView = null;
                 }
             }
         });


### PR DESCRIPTION
progressView is intended for reuse so don't set it to null.

See the comment at https://github.com/turbolinks/turbolinks-android/blob/a2c89a4abfcfed75c68a5b8c8ded5c1d4cd749bd/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java#L755

Currently, the progressView must be configured before every visit or the default progressView settings are used. This change fixed that problem.
For example:
```java
TurbolinksSession.getDefault(this).progressView(LayoutInflater.from(this).inflate(com.basecamp.turbolinks.R.layout.turbolinks_progress, turbolinksView, false), com.basecamp.turbolinks.R.id.turbolinks_default_progress_indicator,Integer.MAX_VALUE);
TurbolinksSession.getDefault(this).visit(locationA);
TurbolinksSession.getDefault(this).visit(locationB);
```
Currently, that will use the customized settings for visiting locationA but the default progress view (including the default delay) for visiting locationB. This behavior seems incorrect and surprising.