### PR TITLE
Hide the progress view when an error occurs

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -423,6 +423,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
     @android.webkit.JavascriptInterface
     public void visitRequestFailedWithStatusCode(final String visitIdentifier, final int statusCode) {
         TurbolinksLog.d("visitRequestFailedWithStatusCode called");
+        hideProgressView(visitIdentifier);
 
         if (TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
             TurbolinksHelper.runOnMainThread(applicationContext, new Runnable() {


### PR DESCRIPTION
When a request for a URL begins, the progress view is shown. However, if that request ends in an error (such as if the URL returns 404 or network access is required but none is available) the progress view is never removed - so the user is stuck with a spinner over the webview.

This change hides the webview following the failure of a request.