### PR TITLE
Add INTERNET permission and compile dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ dependencies {
 ### Prerequisites
 
 1. We recommend using Turbolinks from an activity or an extension of your activity, like a custom controller. This library hasn't been tested with Android Fragments (we don't use them). We'd recommend avoiding Fragments with this library, as they might produce unintended results.
-2. Android API 19+ is required as the `minSdkVersion` in your build.gradle
+2. Android API 19+ is required as the `minSdkVersion` in your build.gradle.
+3. In order for a  [WebView](https://developer.android.com/reference/android/webkit/WebView.html) to access the Internet and load web pages, your application must have the `INTERNET` permission. Make sure you have `<uses-permission android:name="android.permission.INTERNET" />` in your Android manifest.
 
 ### 1. Add TurbolinksView to a Layout
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    'com.basecamp:turbolinks:1.0.3'
+    compile 'com.basecamp:turbolinks:1.0.3'
 }
 ```
 


### PR DESCRIPTION
This PR tries to address the same issues as https://github.com/turbolinks/turbolinks-android/pull/20, but seems like that PR hasn't been active for a couple weeks, so I followed the suggestion and added the INTERNET permission to the `prerequisites` section.

Feel free to close this PR if you guys prefer to continue the discussion and merge in https://github.com/turbolinks/turbolinks-android/pull/20