### PR TITLE
Refactor the Javascript interface and other improvements

### DIFF
--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.1"
 
     defaultConfig {
         applicationId "com.basecamp.turbolinks.demo"
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }
@@ -26,7 +26,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'com.android.support:design:23.2.0'
+    compile 'com.android.support:appcompat-v7:24.1.1'
+    compile 'com.android.support:design:24.1.1'
     compile project(':turbolinks')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.1"
 
     defaultConfig {
         minSdkVersion 19

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -39,7 +39,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'com.google.code.gson:gson:2.4'
     compile 'org.apache.commons:commons-lang3:3.4'
 
     testCompile 'org.assertj:assertj-core:1.7.0'

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -23,6 +23,10 @@ android {
         targetSdkVersion 24
         versionCode 4
         versionName "1.0.2"
+
+        // Define ProGuard rules for this android library project. These rules will be applied when
+        // a consumer of this library sets 'minifyEnabled true'.
+        consumerProguardFiles 'proguard-consumer-rules.pro'
     }
     buildTypes {
         release {

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 buildscript {
-    ext.supportLibVersion = '24.0.0'
+    ext.supportLibVersion = '24.1.1'
 
     repositories {
         jcenter()

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -104,6 +104,8 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+    classpath += fileTree(dir: "$buildDir/intermediates/exploded-aar/", include:"**/classes.jar")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 

--- a/turbolinks/proguard-consumer-rules.pro
+++ b/turbolinks/proguard-consumer-rules.pro
@@ -1,0 +1,9 @@
+# The Android Gradle plugin allows to define ProGuard rules which get embedded in the AAR.
+# These ProGuard rules are automatically applied when a consumer app sets minifyEnabled to true.
+# The custom rule file must be defined using the 'consumerProguardFiles' property in your
+# build.gradle file.
+
+-keepclassmembers com.basecamp.turbolinks.TurbolinksSession$TurbolinksJavascriptInterface {
+    @android.webkit.JavascriptInterface <methods>;
+}
+-keepattributes JavascriptInterface

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksAdapter.java
@@ -1,5 +1,7 @@
 package com.basecamp.turbolinks;
 
+import android.support.annotation.NonNull;
+
 /**
  * <p>Defines callbacks that Turbolinks makes available to your app. This interface is required, and
  * should be implemented in an activity (or similar class).</p>
@@ -46,5 +48,5 @@ public interface TurbolinksAdapter {
      * @param location URL to be visited.
      * @param action Whether to treat the request as an advance (navigating forward) or a replace (back).
      */
-    void visitProposedToLocationWithAction(String location, String action);
+    void visitProposedToLocationWithAction(@NonNull String location, @TurbolinksSession.Action String action);
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.util.Base64;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -32,7 +33,7 @@ class TurbolinksHelper {
      * @param applicationContext An application context.
      * @return The shared WebView.
      */
-    static WebView createWebView(Context applicationContext) {
+    static @NonNull WebView createWebView(@NonNull Context applicationContext) {
         MutableContextWrapper contextWrapper = new MutableContextWrapper(applicationContext);
         WebView webView = new WebView(contextWrapper);
         configureWebViewDefaults(webView);
@@ -47,7 +48,7 @@ class TurbolinksHelper {
      * @param originalUrl Original URL string.
      * @return Encoded, escaped URL string.
      */
-    static String encodeUrl(String originalUrl) {
+    static @NonNull String encodeUrl(@NonNull String originalUrl) {
         try {
             URL newUrl = new URL(originalUrl);
             URI uri = new URI(newUrl.getProtocol(), newUrl.getUserInfo(), newUrl.getHost(), newUrl.getPort(), newUrl.getPath(), newUrl.getQuery(), newUrl.getRef());
@@ -65,7 +66,7 @@ class TurbolinksHelper {
      * @return A base-64 encoded string of the file contents.
      * @throws IOException Typically if a file cannot be found or read in.
      */
-    static String getContentFromAssetFile(Context context, String filePath) throws IOException {
+    static @NonNull String getContentFromAssetFile(@NonNull Context context, @NonNull String filePath) throws IOException {
         InputStream inputStream = context.getAssets().open(filePath);
         byte[] buffer = new byte[inputStream.available()];
         inputStream.read(buffer);
@@ -80,7 +81,7 @@ class TurbolinksHelper {
      * @param context           Any Android context.
      * @param webView           The shared webView.
      */
-    static void injectTurbolinksBridge(final TurbolinksSession turbolinksSession, Context context, WebView webView) {
+    static void injectTurbolinksBridge(@NonNull final TurbolinksSession turbolinksSession, @NonNull Context context,@NonNull WebView webView) {
         try {
             String jsCall = String.format(scriptInjectionFormat, TurbolinksHelper.getContentFromAssetFile(context, "js/turbolinks_bridge.js"));
             runJavascriptRaw(context, webView, jsCall);
@@ -98,7 +99,7 @@ class TurbolinksHelper {
      * @param functionName The Javascript function name only (no parenthesis or parameters).
      * @param params       A comma delimited list of parameter values.
      */
-    static void runJavascript(Context context, final WebView webView, String functionName, Object... params) {
+    static void runJavascript(@NonNull Context context, @NonNull final WebView webView, @NonNull String functionName, Object... params) {
         final String fullJs;
 
         if (params != null) {
@@ -128,7 +129,7 @@ class TurbolinksHelper {
      * @param webView    The shared webView.
      * @param javascript The raw Javascript to be executed, fully escaped/encoded in advance.
      */
-    static void runJavascriptRaw(Context context, final WebView webView, final String javascript) {
+    static void runJavascriptRaw(@NonNull Context context, @NonNull final WebView webView, @NonNull final String javascript) {
         runOnMainThread(context, new Runnable() {
             @Override
             public void run() {
@@ -143,7 +144,7 @@ class TurbolinksHelper {
      * @param context  An activity context.
      * @param runnable A runnable to execute on the main thread.
      */
-    static void runOnMainThread(Context context, Runnable runnable) {
+    static void runOnMainThread(@NonNull Context context, @NonNull Runnable runnable) {
         Handler handler = new Handler(context.getMainLooper());
         handler.post(runnable);
     }
@@ -159,7 +160,7 @@ class TurbolinksHelper {
      * @param webView The shared webView.
      */
     @SuppressLint("SetJavaScriptEnabled")
-    private static void configureWebViewDefaults(WebView webView) {
+    private static void configureWebViewDefaults(@NonNull WebView webView) {
         WebSettings settings = webView.getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setDomStorageEnabled(true);

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -9,6 +9,11 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.annotation.IdRes;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -21,6 +26,8 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -58,6 +65,11 @@ public class TurbolinksSession implements CanScrollUpCallback {
     // Final vars
     // ---------------------------------------------------
 
+
+    @StringDef({ACTION_ADVANCE, ACTION_REPLACE, ACTION_RESTORE})
+    @Retention(RetentionPolicy.SOURCE)
+    @interface Action {}
+
     public static final String ACTION_ADVANCE = "advance";
     static final String ACTION_RESTORE = "restore";
     public static final String ACTION_REPLACE = "replace";
@@ -84,7 +96,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitProposedToLocationWithAction(final String location, final String action) {
+        public void visitProposedToLocationWithAction(@NonNull final String location, @Action @NonNull final String action) {
             TurbolinksLog.d("visitProposedToLocationWithAction called");
 
             TurbolinksHelper.runOnMainThread(applicationContext, new Runnable() {
@@ -103,7 +115,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitStarted(String visitIdentifier, boolean visitHasCachedSnapshot) {
+        public void visitStarted(@NonNull String visitIdentifier, boolean visitHasCachedSnapshot) {
             TurbolinksLog.d("visitStarted called");
 
             currentVisitIdentifier = visitIdentifier;
@@ -121,7 +133,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitRequestCompleted(String visitIdentifier) {
+        public void visitRequestCompleted(@NonNull String visitIdentifier) {
             TurbolinksLog.d("visitRequestCompleted called");
 
             if (TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
@@ -137,7 +149,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitRequestFailedWithStatusCode(final String visitIdentifier, final int statusCode) {
+        public void visitRequestFailedWithStatusCode(@NonNull final String visitIdentifier, final int statusCode) {
             TurbolinksLog.d("visitRequestFailedWithStatusCode called");
             hideProgressView(visitIdentifier);
 
@@ -159,7 +171,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitRendered(String visitIdentifier) {
+        public void visitRendered(@NonNull String visitIdentifier) {
             TurbolinksLog.d("visitRendered called, hiding progress view for identifier: " + visitIdentifier);
             hideProgressView(visitIdentifier);
         }
@@ -174,7 +186,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void visitCompleted(String visitIdentifier, String restorationIdentifier) {
+        public void visitCompleted(@NonNull String visitIdentifier, @NonNull String restorationIdentifier) {
             TurbolinksLog.d("visitCompleted called");
 
             addRestorationIdentifierToMap(restorationIdentifier);
@@ -222,7 +234,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
          */
         @SuppressWarnings("unused")
         @android.webkit.JavascriptInterface
-        public void hideProgressView(final String visitIdentifier) {
+        public void hideProgressView(@NonNull final String visitIdentifier) {
             TurbolinksHelper.runOnMainThread(applicationContext, new Runnable() {
                 @Override
                 public void run() {
@@ -362,6 +374,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
              * override in that situation, since Turbolinks is not yet ready.
              * http://stackoverflow.com/a/6739042/3280911
              */
+            @SuppressWarnings("deprecation")
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String location) {
                 return internalShouldOverrideUrlLoading(view, location);
@@ -422,7 +435,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param context Any Android context.
      * @return TurbolinksSession to be managed by the calling application.
      */
-    public static TurbolinksSession getNew(Context context) {
+    public static @NonNull  TurbolinksSession getNew(@NonNull Context context) {
         TurbolinksLog.d("TurbolinksSession getNew called");
 
         return new TurbolinksSession(context);
@@ -435,7 +448,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param context Any Android context.
      * @return The default, static instance of a TurbolinksSession, guaranteed to not be null.
      */
-    public static TurbolinksSession getDefault(Context context) {
+    public static @NonNull TurbolinksSession getDefault(@NonNull Context context) {
         if (defaultInstance == null) {
             synchronized (TurbolinksSession.class) {
                 if (defaultInstance == null) {
@@ -470,7 +483,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param activity An Android Activity, one per visit.
      * @return The TurbolinksSession to continue the chained calls.
      */
-    public TurbolinksSession activity(Activity activity) {
+    public @NonNull TurbolinksSession activity(@NonNull Activity activity) {
         this.activity = activity;
 
         Context webViewContext = webView.getContext();
@@ -488,7 +501,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param turbolinksAdapter Any class that implements {@link TurbolinksAdapter}.
      * @return The TurbolinksSession to continue the chained calls.
      */
-    public TurbolinksSession adapter(TurbolinksAdapter turbolinksAdapter) {
+    public @NonNull TurbolinksSession adapter(@NonNull TurbolinksAdapter turbolinksAdapter) {
         this.turbolinksAdapter = turbolinksAdapter;
         return this;
     }
@@ -501,7 +514,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param turbolinksView An inflated TurbolinksView from your custom layout.
      * @return The TurbolinksSession to continue the chained calls.
      */
-    public TurbolinksSession view(TurbolinksView turbolinksView) {
+    public @NonNull TurbolinksSession view(@NonNull TurbolinksView turbolinksView) {
         this.turbolinksView = turbolinksView;
         this.turbolinksView.attachWebView(webView, swipeRefreshLayout, screenshotsEnabled, pullToRefreshEnabled);
 
@@ -514,7 +527,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *
      * @param location The URL to visit.
      */
-    public void visit(String location) {
+    public void visit(@NonNull String location) {
         TurbolinksLog.d("visit called");
 
         this.location = location;
@@ -558,7 +571,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *                               inside the progress view (default is 500 ms).
      * @return The TurbolinksSession to continue the chained calls.
      */
-    public TurbolinksSession progressView(View progressView, int progressIndicatorResId, int progressIndicatorDelay) {
+    public @NonNull TurbolinksSession progressView(@NonNull View progressView, @IdRes int progressIndicatorResId, @IntRange(from = 0) int progressIndicatorDelay) {
         this.progressView = progressView;
         this.progressIndicator = progressView.findViewById(progressIndicatorResId);
         this.progressIndicatorDelay = progressIndicatorDelay;
@@ -579,7 +592,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *                                  scroll position.
      * @return The TurbolinksSession to continue the chained calls.
      */
-    public TurbolinksSession restoreWithCachedSnapshot(boolean restoreWithCachedSnapshot) {
+    public @NonNull TurbolinksSession restoreWithCachedSnapshot(boolean restoreWithCachedSnapshot) {
         this.restoreWithCachedSnapshot = restoreWithCachedSnapshot;
         return this;
     }
@@ -596,7 +609,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param name   The unique name for the interface (must not use the reserved name "TurbolinksNative")
      */
     @SuppressLint("JavascriptInterface")
-    public void addJavascriptInterface(Object object, String name) {
+    public void addJavascriptInterface(@NonNull Object object, @NonNull String name) {
         if (TextUtils.equals(name, JAVASCRIPT_INTERFACE_NAME)) {
             throw new IllegalArgumentException(JAVASCRIPT_INTERFACE_NAME + " is a reserved Javascript Interface name.");
         }
@@ -614,7 +627,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *
      * @return The attached activity.
      */
-    public Activity getActivity() {
+    public @NonNull  Activity getActivity() {
         return activity;
     }
 
@@ -623,7 +636,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *
      * @return The WebView used by Turbolinks.
      */
-    public WebView getWebView() {
+    public @NonNull WebView getWebView() {
         return webView;
     }
 
@@ -643,7 +656,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param functionName The name of the function, without any parenthesis or params
      * @param params       A comma delimited list of params. Params will be automatically JSONified.
      */
-    public void runJavascript(final String functionName, final Object... params) {
+    public void runJavascript(@NonNull final String functionName, @NonNull final Object... params) {
         TurbolinksHelper.runJavascript(applicationContext, webView, functionName, params);
     }
 
@@ -652,7 +665,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *
      * @param rawJavascript The full Javascript string that will be executed by the WebView.
      */
-    public void runJavascriptRaw(String rawJavascript) {
+    public void runJavascriptRaw(@NonNull String rawJavascript) {
         TurbolinksHelper.runJavascriptRaw(applicationContext, webView, rawJavascript);
     }
 
@@ -700,7 +713,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * @param location URL to visit.
      * @param action   Whether to treat the request as an advance (navigating forward) or a replace (back).
      */
-    public void visitLocationWithAction(String location, String action) {
+    public void visitLocationWithAction(@NonNull String location, @Action @NonNull String action) {
         this.location = location;
         runJavascript("webView.visitLocationWithActionAndRestorationIdentifier", TurbolinksHelper.encodeUrl(location), action, getRestorationIdentifierFromMap());
     }
@@ -725,7 +738,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      * Gets the current location
      * @return the current location
      */
-    public String getLocation(){
+    public @NonNull String getLocation(){
         return location;
     }
 
@@ -745,7 +758,7 @@ public class TurbolinksSession implements CanScrollUpCallback {
      *
      * @param value Restoration ID provided by Turbolinks.
      */
-    private void addRestorationIdentifierToMap(String value) {
+    private void addRestorationIdentifierToMap(@NonNull String value) {
         if (activity != null) {
             restorationIdentifierMap.put(activity.toString(), value);
         }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSwipeRefreshLayout.java
@@ -1,6 +1,7 @@
 package com.basecamp.turbolinks;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 
@@ -15,7 +16,7 @@ public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
      *
      * @param context Refer to SwipeRefreshLayout
      */
-    public TurbolinksSwipeRefreshLayout(Context context) {
+    public TurbolinksSwipeRefreshLayout(@NonNull Context context) {
         super(context);
     }
 
@@ -25,7 +26,7 @@ public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
      * @param context Refer to SwipeRefreshLayout
      * @param attrs Refer to SwipeRefreshLayout
      */
-    public TurbolinksSwipeRefreshLayout(Context context, AttributeSet attrs) {
+    public TurbolinksSwipeRefreshLayout(@NonNull Context context, @NonNull AttributeSet attrs) {
         super(context, attrs);
     }
 
@@ -47,5 +48,5 @@ public class TurbolinksSwipeRefreshLayout extends SwipeRefreshLayout {
      *
      * @param callback The custom callback to be set
      */
-    public void setCallback(CanScrollUpCallback callback) { this.callback = callback; }
+    public void setCallback(@NonNull CanScrollUpCallback callback) { this.callback = callback; }
 }

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -8,6 +8,9 @@ import android.graphics.Canvas;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,7 +36,7 @@ public class TurbolinksView extends FrameLayout {
      *
      * @param context Refer to FrameLayout.
      */
-    public TurbolinksView(Context context) {
+    public TurbolinksView(@NonNull Context context) {
         super(context);
     }
 
@@ -43,7 +46,7 @@ public class TurbolinksView extends FrameLayout {
      * @param context Refer to FrameLayout.
      * @param attrs Refer to FrameLayout.
      */
-    public TurbolinksView(Context context, AttributeSet attrs) {
+    public TurbolinksView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
     }
 
@@ -54,7 +57,7 @@ public class TurbolinksView extends FrameLayout {
      * @param attrs Refer to FrameLayout.
      * @param defStyleAttr Refer to FrameLayout.
      */
-    public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr) {
+    public TurbolinksView(@NonNull Context context, @Nullable  AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
@@ -67,7 +70,7 @@ public class TurbolinksView extends FrameLayout {
      * @param defStyleRes Refer to FrameLayout.
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public TurbolinksView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    public TurbolinksView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
 
@@ -88,7 +91,8 @@ public class TurbolinksView extends FrameLayout {
      * @param delay The delay before showing the progressIndicator in the view. The default progress view
      *              is 500 ms.
      */
-    void showProgress(final View progressView, final View progressIndicator, int delay) {
+    @UiThread
+    void showProgress(@NonNull final View progressView, @NonNull final View progressIndicator, int delay) {
         TurbolinksLog.d("showProgress called");
 
         // Don't show the progress view if a screenshot is available
@@ -115,6 +119,7 @@ public class TurbolinksView extends FrameLayout {
      * <p>Removes the progress view and/or screenshot from the TurbolinksView, so the webview is
      * visible underneath.</p>
      */
+    @UiThread
     void hideProgress() {
         removeProgressView();
         removeScreenshotView();
@@ -128,7 +133,8 @@ public class TurbolinksView extends FrameLayout {
      * @param screenshotsEnabled Indicates whether screenshots are enabled for the current session.
      * @param pullToRefreshEnabled Indicates whether pull to refresh is enabled for the current session.
      */
-    void attachWebView(WebView webView, TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled, boolean pullToRefreshEnabled) {
+    @UiThread
+    void attachWebView(@NonNull WebView webView, @NonNull TurbolinksSwipeRefreshLayout swipeRefreshLayout, boolean screenshotsEnabled, boolean pullToRefreshEnabled) {
         if (swipeRefreshLayout.getParent() == this) return;
 
         swipeRefreshLayout.setEnabled(pullToRefreshEnabled);
@@ -154,7 +160,8 @@ public class TurbolinksView extends FrameLayout {
      * Used to remove the child WebView from the swipeRefreshLayout.
      * @param child WebView that is child of swipeRefreshLayout
      */
-    private void removeChildViewFromSwipeRefresh(View child) {
+    @UiThread
+    private void removeChildViewFromSwipeRefresh(@NonNull View child) {
         ViewGroup parent = (ViewGroup) child.getParent();
         if (parent != null) { parent.removeView(child); }
     }
@@ -162,6 +169,7 @@ public class TurbolinksView extends FrameLayout {
     /**
      * Removes the progress view as a child of TurbolinksView
      */
+    @UiThread
     private void removeProgressView() {
         if (progressView == null) return;
 
@@ -172,6 +180,7 @@ public class TurbolinksView extends FrameLayout {
     /**
      * Removes the screenshot view as a child of TurbolinksView
      */
+    @UiThread
     private void removeScreenshotView() {
         if (screenshotView == null) return;
 
@@ -183,6 +192,7 @@ public class TurbolinksView extends FrameLayout {
     /**
      * <p>Creates a screenshot of the current webview content and makes it the top visible view.</p>
      */
+    @UiThread
     private void screenshotView() {
         // Only take a screenshot if the activity is not finishing
         if (getContext() instanceof Activity && ((Activity) getContext()).isFinishing()) return;
@@ -205,7 +215,7 @@ public class TurbolinksView extends FrameLayout {
      * <p>Creates a bitmap screenshot of the webview contents from the canvas.</p>
      * @return The screenshot of the webview contents.
      */
-    private Bitmap getScreenshotBitmap() {
+    private @NonNull Bitmap getScreenshotBitmap() {
         if (getWidth() <= 0 || getHeight() <= 0) return null;
 
         Bitmap bitmap = Bitmap.createBitmap(getWidth(), getHeight(), Bitmap.Config.ARGB_8888);


### PR DESCRIPTION
Refactor the Javascript interface so it's no longer publicly accessible reducing potential errors and confusion
Make ACTION_REPLACE and ACTION_ADVANCE public for ease of use by consumers
Add TurbolinksSession.visitBack() convenience method
Set location in TurbolinksSession.visitLocationWithAction(String, String)
Hide the progress view when an error occurs
Don't set progressView to null in TurbolinksSession.hideProgressView
Add TurbolinksSession.getLocation() method
Add TurbolinksSession.reload() method
