### PR TITLE
Loosen minSdkVersion so this library can be selectively enabled 

### DIFF
--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion "24.0.1"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 15
         targetSdkVersion 24
         versionCode 5
         versionName "1.0.3"


### PR DESCRIPTION
Hi,

This pull request loosens the minSdkVersion so turbolinks-android can be included and selectively enabled/disabled depending on whether the device has the required SDK version.

Example:
    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
      // Implementation using Turbolinks
    }
    else {
      // Non-turbolinks implementation
    }
    
The reason I chose 15 as minSdkVersion is because that's what we use for our production app, so this is the min version that has been tested.

Thanks
