### PR TITLE
fix: CSS full height background

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksHelper.java
@@ -5,10 +5,12 @@ import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Handler;
 import android.util.Base64;
+import android.view.ViewGroup;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import android.widget.FrameLayout;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -36,6 +38,7 @@ class TurbolinksHelper {
         MutableContextWrapper contextWrapper = new MutableContextWrapper(applicationContext);
         WebView webView = new WebView(contextWrapper);
         configureWebViewDefaults(webView);
+        setWebViewLayoutParams(webView);
 
         return webView;
     }
@@ -166,5 +169,16 @@ class TurbolinksHelper {
         settings.setDatabaseEnabled(true);
 
         webView.setWebChromeClient(new WebChromeClient());
+    }
+
+    /**
+     * Sets the WebView's width/height layout params to MATCH_PARENT
+     *
+     * @param webView The shared webView.
+     */
+    private static void setWebViewLayoutParams(WebView webView) {
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        webView.setLayoutParams(params);
     }
 }


### PR DESCRIPTION
Addresses the issue mentioned here #43 where CSS height set to 100% was not being applied to backgrounds
Caused by the layout params of the WebView not having been set to MATCH_PARENT
