### PR TITLE
make TurbolinksSession.setDebugLoggingEnabled static

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -668,7 +668,7 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
      *
      * @param enabled If true debug logging is enabled.
      */
-    public void setDebugLoggingEnabled(boolean enabled) {
+    public static void setDebugLoggingEnabled(boolean enabled) {
         TurbolinksLog.setDebugLoggingEnabled(enabled);
     }
 


### PR DESCRIPTION
...so that it can be set before initialising the instance

without having this static, all the debug logs made before/during initialisation of the TurbolinksSession instance aren't visible  