### PR TITLE
Escape spaces in links for Markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ In more complex apps, you'll most likely want to do some routing logic here. Sho
 
 #### onPageFinished
 
-This is a callback that's executed at the end of the standard [WebViewClient's onPageFinished](http://developer.android.com/reference/android/webkit/WebViewClient.html#onPageFinished(android.webkit.WebView, java.lang.String)) method.
+This is a callback that's executed at the end of the standard [WebViewClient's onPageFinished](http://developer.android.com/reference/android/webkit/WebViewClient.html#onPageFinished(android.webkit.WebView,%20java.lang.String)) method.
 
 This callback will only be fired once upon cold booting. If there is any action you need to take after the first full page load is complete, just once, this is the place to do it.
 
@@ -133,7 +133,7 @@ It's similar conceptually to onPageFinished, except this callback will be called
 
 #### onReceivedError
 
-This is a callback that's executed at the end of the standard [WebViewClient's onReceivedError](http://developer.android.com/reference/android/webkit/WebViewClient.html#onReceivedError(android.webkit.WebView, int, java.lang.String, java.lang.String)) method.
+This is a callback that's executed at the end of the standard [WebViewClient's onReceivedError](http://developer.android.com/reference/android/webkit/WebViewClient.html#onReceivedError(android.webkit.WebView,%20int,%20java.lang.String,%20java.lang.String)) method.
 
 **We recommend you implement this method.** Otherwise, your user will see an endless progress view/spinner without something that handles the error. You can handle the error however you like -- send the user to a different page, show a native error screen, etc.
 


### PR DESCRIPTION
This just fixes some links in the README that aren't rendered correctly by Markdown because of the spaces in them. I've escaped the spaces so the links can be rendered and checked that the links still direct to the correct page.