### PR TITLE
Workaround for Chrome 64 accessibility crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.basecamp.turbolinks.demo"
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -26,7 +26,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.1'
-    compile 'com.android.support:design:25.1.1'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:design:27.0.2'
     compile project(':turbolinks')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 23 12:05:01 CST 2017
+#Mon Feb 05 08:55:13 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/turbolinks/build.gradle
+++ b/turbolinks/build.gradle
@@ -3,25 +3,25 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 buildscript {
-    ext.supportLibVersion = '25.1.1'
+    ext.supportLibVersion = '27.0.2'
     ext.libVersionName = '1.0.7'
 
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 9
         versionName "$libVersionName"
 

--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksView.java
@@ -158,7 +158,17 @@ public class TurbolinksView extends FrameLayout {
             TurbolinksView previousTurbolinksView = (TurbolinksView) previousRefreshLayout.getParent();
 
             if (screenshotsEnabled) previousTurbolinksView.screenshotView();
-            previousRefreshLayout.removeView(webView);
+
+            try {
+                // This is an admittedly hacky workaround, but it buys us some time as we investigate
+                // a potential bug with Chrome 64, which is currently throwing an IllegalStateException
+                // when accessibility services (like Talkback or 1password) are enabled.
+                // We're tracking this bug on the Chromium issue tracker:
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=806108
+                previousRefreshLayout.removeView(webView);
+            } catch (Exception e) {
+                previousRefreshLayout.removeView(webView);
+            }
         }
 
         // Set the webview background to match the container background


### PR DESCRIPTION
This is a temporary workaround for a Chrome 64 accessibility crash.

This crash coincided with the [Chrome 64 release](https://chromereleases.googleblog.com/2018/01/chrome-for-android-update.html) on 1/23/18. We noticed the crashes in Basecamp 3 to increase around 1/26/18 with a big spike on 1/29/18, most likely due to Chrome's rollout increasing + being a Monday morning.

We have tested this workaround/patch as a temp fix in Basecamp for the past week or so, and everything looks good. This isn't intended to be a long term fix, but one to hold us over until we find out if the [Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=806108) is acknowledged and/or fixed.