### PR TITLE
requestFailedWithStatusCode is hiding progressView

### DIFF
--- a/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
+++ b/turbolinks/src/main/java/com/basecamp/turbolinks/TurbolinksSession.java
@@ -434,7 +434,6 @@ public class TurbolinksSession implements TurbolinksScrollUpCallback {
     @android.webkit.JavascriptInterface
     public void visitRequestFailedWithStatusCode(final String visitIdentifier, final int statusCode) {
         TurbolinksLog.d("visitRequestFailedWithStatusCode called");
-        hideProgressView(visitIdentifier);
 
         if (TextUtils.equals(visitIdentifier, currentVisitIdentifier)) {
             TurbolinksHelper.runOnMainThread(applicationContext, new Runnable() {


### PR DESCRIPTION
According to the documentation about `requestFailedWithStatusCode` I should see an endless progress view/spinner, instead it I see the last page.