### PR TITLE
Fix behavior when tapping on a same-page anchor link

### DIFF
--- a/turbolinks/src/main/assets/js/turbolinks_bridge.js
+++ b/turbolinks/src/main/assets/js/turbolinks_bridge.js
@@ -54,7 +54,11 @@ TLWebView.prototype = {
     // -----------------------------------------------------------------------
 
     visitProposedToLocationWithAction: function(location, action) {
-        TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action);
+        if (this.controller.locationIsSamePageAnchor(location)) {
+            this.controller.scrollToAnchor(location.anchor);
+        } else {
+            TurbolinksNative.visitProposedToLocationWithAction(location.absoluteURL, action);
+        }
     },
 
     visitStarted: function(visit) {


### PR DESCRIPTION
This pull request aims to mirror the code in https://github.com/turbolinks/turbolinks-ios/pull/126, to fix the behaviour when tapping on a link to an anchor on the same page.